### PR TITLE
docs: add Fronteir AI hosted deployment option

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 A powerful Model Context Protocol (MCP) server that provides AI-powered image and video analysis using Google Gemini and Vertex AI models.
 
+## Hosted deployment
+
+A hosted deployment is available on [Fronteir AI](https://fronteir.ai/mcp/tan-yong-sheng-ai-vision-mcp).
+
 ## Features
 
 - **Dual Provider Support**: Choose between Google Gemini API and Vertex AI


### PR DESCRIPTION
Love the project!

Adds a short note in the README that a hosted deployment is available on [Fronteir AI](https://fronteir.ai/mcp/tan-yong-sheng-ai-vision-mcp)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added "Hosted deployment" section to README with information about accessing an external hosted instance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->